### PR TITLE
Fix directory-picker freeze on large folders; optimize file browser

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: psychds
-Title: "Dashboard for Creating and Validating 'Psych-DS' Datasets"
+Title: Tools for Creating and Validating 'Psych-DS' Datasets
 Version: 0.1.0
 Authors@R:
     c(person("Massachusetts Institute of Technology",
@@ -12,7 +12,7 @@ Authors@R:
              email = "mekline@mit.edu",
              role = "aut",
              comment = c(ORCID = "0000-0003-2217-9331")))
-Description: Provides a 'Shiny' application and helper functions for adopting 'Psych-DS' (<https://psych-ds.github.io/>), a community data standard for organizing and documenting datasets in the psychological and behavioral sciences inspired by the Brain Imaging Data Standard ('BIDS'). A guided interface walks researchers through the dataset creation process, organizing tabular data files into proper 'Psych-DS' directory structures, generating new, compliant, keyword- based filenames, and generating machine-readable 'JSON' metadata. Additional tools support building and editing data dictionaries with variable-level descriptions, validating datasets against the full 'Psych-DS' specification via an embedded JavaScript validator, exploring dataset contents interactively, and uploading completed datasets to the Open Science Framework ('OSF'). 
+Description: Provides a 'Shiny' application and helper functions for adopting 'Psych-DS' (<https://psych-ds.github.io/>), a community data standard for organizing and documenting datasets in the psychological and behavioral sciences inspired by the Brain Imaging Data Standard ('BIDS'). A guided interface walks researchers through the dataset creation process, organizing tabular data files into proper 'Psych-DS' directory structures, generating new, compliant, keyword-based filenames, and generating machine-readable 'JSON' metadata. Additional tools support building and editing data dictionaries with variable-level descriptions, validating datasets against the full 'Psych-DS' specification via an embedded JavaScript validator, exploring dataset contents interactively, and uploading completed datasets to the Open Science Framework ('OSF').
 License: MIT + file LICENSE
 URL: https://github.com/psych-ds/psychds-r
 BugReports: https://github.com/psych-ds/psychds-r/issues
@@ -27,6 +27,7 @@ Imports:
     rstudioapi,
     shiny (>= 1.7.0),
     tools,
+    shinyFiles,
     utils
 Suggests:
     crosstalk,
@@ -36,9 +37,8 @@ Suggests:
     miniUI,
     rmarkdown,
     shinydashboard,
-    shinyFiles,
+    fs,
     shinyjs,
-    spelling,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 SystemRequirements: Node.js (>= 18.0.0)

--- a/inst/shiny/global.R
+++ b/inst/shiny/global.R
@@ -5,6 +5,7 @@
 #' It's loaded before both ui.R and server.R.
 
 # Load required packages
+source("modules/directory_picker.R")
 library(shiny)
 library(shinydashboard)
 library(shinyjs)

--- a/inst/shiny/modules/directory_picker.R
+++ b/inst/shiny/modules/directory_picker.R
@@ -1,0 +1,291 @@
+# directory_picker.R
+# ---------------------------------------------------------------------------
+# Lightweight, files-free directory picker for the Psych-DS Shiny app.
+#
+# Drop-in replacement for the shinyFiles-based directoryInputUI() /
+# directoryInputServer(). Same function names, same arguments, same return
+# value (a reactive that yields the chosen path), so step1Server() and the
+# directoryInputUI(ns("project_dir")) call site need no changes.
+#
+# WHY: shinyFiles' shinyDirChoose() unconditionally runs its fileGetter() on
+# every folder you open -- dir_ls() + fs::file_info() (a full stat on EVERY
+# entry) + dir.exists() -- and only filters afterwards. On a folder with ~100k
+# files that stat-storm blocks the single-threaded R process and ships a
+# 100k-row payload the browser then has to render, which is what froze the
+# weaker test machines. A folder picker never needs file metadata, so this
+# module enumerates ONLY one level of subdirectories (list.dirs(recursive =
+# FALSE)) and never touches files at all.
+# ---------------------------------------------------------------------------
+
+#' Directory Input UI (files-free)
+#'
+#' @param id Module ID
+#' @param value Initial path value
+#' @param placeholder Placeholder text for the path field
+#' @noRd
+directoryInputUI <- function(id, value = "", placeholder = "Project directory path") {
+  ns <- NS(id)
+  tagList(
+    div(
+      class = "directory-input",
+      textInput(
+        ns("path"),
+        label = NULL,
+        value = value,
+        placeholder = placeholder,
+        width = "100%"
+      ),
+      actionButton(
+        ns("browse"),
+        label = "...",
+        title = "Browse for a project directory",
+        class = "browse-btn"
+      )
+    ),
+    # Pre-empt the "where are my files?" confusion right at the field.
+    div(
+      style = "font-size:12px; color:#888; margin-top:4px;",
+      "Choose or type the folder that holds your data. You're selecting a ",
+      "folder, not individual files."
+    )
+  )
+}
+
+#' List immediate subdirectories cheaply (no file metadata, no recursion)
+#'
+#' This is the whole performance trick: one directory read, directories only.
+#' We never call fs::file_info() and never enumerate files.
+#'
+#' @param path Directory to inspect
+#' @param show_hidden Whether to include dot-directories
+#' @return Character vector of absolute subdirectory paths
+#' @noRd
+list_subdirs <- function(path, show_hidden = FALSE) {
+  if (is.null(path) || is.na(path) || path == "" || !dir.exists(path)) {
+    return(character(0))
+  }
+  dirs <- tryCatch(
+    list.dirs(path, full.names = TRUE, recursive = FALSE),
+    error = function(e) character(0)
+  )
+  if (length(dirs) == 0) return(dirs)
+  if (!show_hidden) {
+    dirs <- dirs[!startsWith(basename(dirs), ".")]
+  }
+  sort(dirs)
+}
+
+#' Available volume roots (Home, filesystem/Windows drive roots)
+#' @noRd
+get_path_volumes <- function() {
+  vols <- c(Home = path.expand("~"))
+  if (.Platform$OS.type == "windows") {
+    win_vols <- tryCatch(shinyFiles::getVolumes()(), error = function(e) NULL)
+    if (!is.null(win_vols)) vols <- c(vols, win_vols)
+  } else {
+    vols <- c(vols, Root = "/")
+  }
+  vols
+}
+
+#' Normalize and validate a candidate directory path
+#'
+#' Returns the normalized path if it exists and is a directory, else NULL.
+#' @noRd
+.resolve_dir <- function(path) {
+  if (is.null(path) || !nzchar(path)) return(NULL)
+  path <- path.expand(path)             # handle a leading ~/
+  if (!dir.exists(path)) return(NULL)
+  normalizePath(path, winslash = "/", mustWork = FALSE)
+}
+
+#' Directory Input Server (files-free)
+#'
+#' @param id Module ID
+#' @param state Global state reactiveValues
+#' @param session Parent session (unused; kept for signature compatibility)
+#' @return A reactive returning the currently selected directory path
+#' @noRd
+directoryInputServer <- function(id, state, session) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    path_value <- reactiveVal("")              # the committed selection
+    nav_path   <- reactiveVal(path.expand("~")) # where the browser is currently pointed
+
+    # Restore a previously chosen directory from global state
+    observe({
+      if (!is.null(state$project_dir) && state$project_dir != "" && path_value() == "") {
+        updateTextInput(session, "path", value = state$project_dir)
+        path_value(state$project_dir)
+      }
+    })
+
+    # Commit a chosen directory: update field, state, and close the modal.
+    commit_selection <- function(chosen) {
+      updateTextInput(session, "path", value = chosen)
+      path_value(chosen)
+      state$project_dir <- chosen
+      removeModal()
+    }
+
+    # Live browser body: current location + subfolder list. Reactive on
+    # nav_path(), so navigating updates it in place inside the open modal.
+    output$dir_list <- renderUI({
+      cur <- nav_path()
+      subdirs <- list_subdirs(cur)
+
+      list_body <- if (length(subdirs) == 0) {
+        div(
+          style = "color:#999; padding:14px; text-align:center;",
+          "No subfolders here \u2014 use \u201cSelect this folder\u201d to choose this directory."
+        )
+      } else {
+        lapply(subdirs, function(d) {
+          div(
+            class = "dir-row",
+            style = paste0(
+              "padding:6px 10px; cursor:pointer; border-bottom:1px solid #eee; ",
+              "display:flex; align-items:center;"
+            ),
+            onmouseover = "this.style.backgroundColor='#f5f5f5'",
+            onmouseout  = "this.style.backgroundColor=''",
+            onclick = sprintf(
+              "Shiny.setInputValue('%s', %s, {priority:'event'})",
+              ns("navigate"),
+              jsonlite::toJSON(d, auto_unbox = TRUE)
+            ),
+            icon("folder", style = "color:#f0ad4e; margin-right:8px;"),
+            span(basename(d))
+          )
+        })
+      }
+
+      tagList(
+        div(
+          style = "font-size:12px; color:#666; margin-bottom:4px;",
+          "Current location:"
+        ),
+        div(
+          style = paste0(
+            "padding:6px 8px; background:#f8f9fa; border:1px solid #ddd; ",
+            "border-radius:4px; margin-bottom:8px; word-break:break-all; font-family:monospace;"
+          ),
+          cur
+        ),
+        div(
+          style = paste0(
+            "max-height:300px; overflow-y:auto; border:1px solid #ddd; ",
+            "border-radius:4px; background:#fff;"
+          ),
+          list_body
+        )
+      )
+    })
+
+    open_modal <- function() {
+      showModal(modalDialog(
+        title = "Select a project directory",
+
+        # Explain why no files are listed -- the source of the confusion.
+        div(
+          style = paste0(
+            "background:#eef5fb; border:1px solid #cfe2f3; border-radius:4px; ",
+            "padding:10px 12px; margin-bottom:12px; font-size:13px; color:#31708f;"
+          ),
+          icon("circle-info", style = "margin-right:6px;"),
+          HTML(paste0(
+            "This browser lists <strong>folders only</strong>. Psych-DS treats an ",
+            "entire folder as your dataset, so individual files (CSVs, JSON, etc.) ",
+            "aren't shown here \u2014 that's expected. Open the folder you want, then ",
+            "click \u201cSelect this folder.\u201d"
+          ))
+        ),
+
+        # Direct-path entry: jump the browser there, or select it outright.
+        div(
+          textInput(
+            ns("jump_path"),
+            label = "Or enter a path directly:",
+            value = nav_path(),
+            width = "100%"
+          ),
+          div(
+            style = "margin-top:-6px; margin-bottom:12px;",
+            actionButton(ns("go_path"), "Open here", class = "btn-default btn-sm"),
+            actionButton(ns("use_path"), "Use this path", class = "btn-primary btn-sm"),
+            span(
+              style = "margin-left:8px; font-size:12px; color:#888;",
+              "\u201cOpen here\u201d browses from this path; \u201cUse this path\u201d selects it."
+            )
+          )
+        ),
+
+        uiOutput(ns("dir_list")),
+        size = "l",
+        easyClose = TRUE,
+        footer = tagList(
+          actionButton(ns("go_up"), HTML("&uarr; Up"), class = "btn-default"),
+          modalButton("Cancel"),
+          actionButton(ns("select_current"), "Select this folder", class = "btn-primary")
+        )
+      ))
+    }
+
+    # Open the browser, starting from the most sensible existing location
+    observeEvent(input$browse, {
+      start <- .resolve_dir(input$path)
+      if (is.null(start)) start <- .resolve_dir(path_value())
+      if (is.null(start)) start <- path.expand("~")
+      nav_path(start)
+      open_modal()
+    })
+
+    # Descend into a clicked subfolder
+    observeEvent(input$navigate, {
+      target <- .resolve_dir(input$navigate)
+      if (!is.null(target)) nav_path(target)
+    })
+
+    # Go up one level (stops at filesystem root)
+    observeEvent(input$go_up, {
+      parent <- .resolve_dir(dirname(nav_path()))
+      if (!is.null(parent)) nav_path(parent)
+    })
+
+    # Direct path -> jump the browser to that location (opening level)
+    observeEvent(input$go_path, {
+      target <- .resolve_dir(input$jump_path)
+      if (!is.null(target)) {
+        nav_path(target)
+      } else {
+        showNotification("That path doesn't exist or isn't a folder.", type = "warning")
+      }
+    })
+
+    # Direct path -> select it outright, no browsing needed
+    observeEvent(input$use_path, {
+      chosen <- .resolve_dir(input$jump_path)
+      if (!is.null(chosen)) {
+        commit_selection(chosen)
+      } else {
+        showNotification("That path doesn't exist or isn't a folder.", type = "warning")
+      }
+    })
+
+    # Commit the folder the browser is currently pointed at
+    observeEvent(input$select_current, {
+      commit_selection(nav_path())
+    })
+
+    # Honor manual typing/pasting in the main field
+    observeEvent(input$path, {
+      if (!is.null(input$path) && input$path != "" && input$path != path_value()) {
+        path_value(input$path)
+        state$project_dir <- input$path
+      }
+    })
+
+    return(path_value)
+  })
+}

--- a/inst/shiny/modules/server_modules.R
+++ b/inst/shiny/modules/server_modules.R
@@ -1303,88 +1303,7 @@ generate_dictionary_html <- function(dictionary_data,
   return(result)
 }
 
-#' Directory Input Server Module - Fixed Version
-#'
-#' Handles directory selection and validation
-#'
-#' @param id The module ID
-#' @param state Global state reactive values
-#' @param session The current session object
-directoryInputServer <- function(id, state, session) {
-  moduleServer(id, function(input, output, session) {
-    # Create a reactive value to store the current path
-    path_value <- reactiveVal("")
 
-    # Set up directory selection
-    volumes <- c(Home = "~")
-    if (.Platform$OS.type == "windows") {
-      volumes <- c(volumes, getVolumes()())
-    }
-
-    shinyDirChoose(
-      input,
-      "select",
-      roots = volumes,
-      session = session,
-      restrictions = system.file(package = "base")
-    )
-    
-    # Restore path from state when module initializes or when returning to step
-    observe({
-      # Restore from state if available and current value is empty
-      if (!is.null(state$project_dir) && state$project_dir != "" && path_value() == "") {
-        updateTextInput(session, "path", value = state$project_dir)
-        path_value(state$project_dir)
-        if (isTRUE(getOption("psychds.verbose"))) {
-          message("Restored directory path from state: ", state$project_dir)
-        }
-      }
-    })
-
-    # Update the project directory input when a directory is selected
-    observeEvent(input$select, {
-      tryCatch({
-        if (!is.null(input$select)) {
-          selected_dir <- parseDirPath(volumes, input$select)
-          if (isTRUE(getOption("psychds.verbose"))) {
-            message("Directory selected: ", selected_dir)
-          }
-
-          if (length(selected_dir) > 0 && selected_dir != "") {
-            # Update input field
-            updateTextInput(session, "path", value = selected_dir)
-
-            # Update our reactive value
-            path_value(selected_dir)
-
-            # Update global state
-            state$project_dir <- selected_dir
-          }
-        }
-      }, error = function(e) {
-        message("Error selecting directory: ", e$message)
-      })
-    })
-
-    # Also monitor manual changes to the path input
-    observeEvent(input$path, {
-      if (isTRUE(getOption("psychds.verbose"))) {
-        message("Path input changed to: ", input$path)
-      }
-
-      if (input$path != "" && input$path != path_value()) {
-        # Update reactive value
-        path_value(input$path)
-
-        # Update global state
-        state$project_dir <- input$path
-      }
-    })
-
-    # Return reactive that provides current path
-    return(path_value)
-  })
-}
 
 #' List Data Files (CSV and TSV)
 #'
@@ -1396,17 +1315,24 @@ list_data_files <- function(dir_path) {
   if (is.null(dir_path) || dir_path == "" || !dir.exists(dir_path)) {
     return(character(0))
   }
-  
-  # Find all CSV and TSV files recursively
-  files <- list.files(
-    dir_path,
-    pattern = "\\.(csv|tsv)$",
-    recursive = TRUE,
-    full.names = FALSE,
-    ignore.case = TRUE
+  # CSV/TSV recursively. Use fs (faster classification via readdir d_type,
+  # avoids a stat() per entry) with a case-insensitive extension regexp;
+  # fall back to base list.files() if fs is unavailable.
+  root <- path.expand(dir_path)
+  pat  <- "\\.([cC][sS][vV]|[tT][sS][vV])$"
+  tryCatch(
+    {
+      if (requireNamespace("fs", quietly = TRUE)) {
+        hits <- fs::dir_ls(root, recurse = TRUE, type = "file",
+                           regexp = pat, fail = FALSE)
+        as.character(fs::path_rel(hits, start = root))
+      } else {
+        list.files(dir_path, pattern = "\\.(csv|tsv)$", recursive = TRUE,
+                   full.names = FALSE, ignore.case = TRUE)
+      }
+    },
+    error = function(e) character(0)
   )
-  
-  return(files)
 }
 
 #' Organize Directory Hierarchy
@@ -1481,6 +1407,17 @@ fileBrowserServer <- function(id, state, dir_path, session) {
   moduleServer(id, function(input, output, session) {
     # Store selected files
     selected <- reactiveVal(character(0))
+
+    # Cache the recursive scan: runs once per directory and is reused by every
+    # handler and the renderUI, so clicking a file never re-walks the disk.
+    files_r <- reactive({
+      d <- dir_path()
+      if (is.null(d) || d == "") return(character(0))
+      list_data_files(d)
+    })
+    hierarchy_r <- reactive({
+      organize_directory_hierarchy(files_r())
+    })
     
     # Track the last directory to detect changes
     last_dir <- reactiveVal(NULL)
@@ -1551,7 +1488,7 @@ fileBrowserServer <- function(id, state, dir_path, session) {
       }
 
       # Get all files
-      all_files <- list_data_files(dir_path())
+      all_files <- all_files <- files_r()
 
       # Find files in this directory
       dir_files <- all_files[startsWith(all_files, dir_prefix)]
@@ -1579,7 +1516,7 @@ fileBrowserServer <- function(id, state, dir_path, session) {
       }
       
       # Get all files in the current directory
-      all_files <- list_data_files(dir_path())
+      all_files <- all_files <- files_r()
       
       # Select all files
       selected(all_files)
@@ -1601,14 +1538,9 @@ fileBrowserServer <- function(id, state, dir_path, session) {
       state$data_files <- selected()
     })
 
-    # Render the file browser with complete hierarchy
+    # Render the file browser (cached scan + O(n) build)
     output$file_container <- renderUI({
       current_dir <- dir_path()
-      if (isTRUE(getOption("psychds.verbose"))) {
-        message("Rendering file container for: ", current_dir)
-      }
-
-      # If no directory selected
       if (is.null(current_dir) || current_dir == "") {
         return(div(
           style = "text-align: center; padding-top: 30px; color: #999;",
@@ -1616,10 +1548,7 @@ fileBrowserServer <- function(id, state, dir_path, session) {
         ))
       }
 
-      # Get data files (CSV/TSV)
-      files <- list_data_files(current_dir)
-
-      # If no files found
+      files <- files_r()
       if (length(files) == 0) {
         return(div(
           style = "text-align: center; padding-top: 30px; color: #999;",
@@ -1627,133 +1556,96 @@ fileBrowserServer <- function(id, state, dir_path, session) {
         ))
       }
 
-      # Create a hierarchical directory structure
-      hierarchy <- organize_directory_hierarchy(files)
-
-      # Sort directories by their full path to maintain hierarchy order (only if there are directories)
+      hierarchy <- hierarchy_r()
       dir_paths <- names(hierarchy)
       if (length(dir_paths) > 0) {
-        dir_paths <- dir_paths[order(sapply(dir_paths, function(d) {
-          # Count the number of path components to sort by depth
-          length(strsplit(d, "/")[[1]])
-        }), dir_paths)]
+        dir_paths <- dir_paths[order(
+          sapply(dir_paths, function(d) length(strsplit(d, "/")[[1]])),
+          dir_paths
+        )]
       }
 
-      # Get current selection count
       current_selection <- selected()
       num_selected <- length(current_selection)
-      
-      # Build the UI
-      ui_elements <- tagList(
-        # File count with selection count
-        div(style = "color: #999; font-size: 12px; margin-bottom: 10px;",
-            paste0("Found ", length(files), " data files, selected ", num_selected))
-      )
+      ns <- session$ns
 
-      # Track previously rendered directories to avoid duplicates
-      rendered_dirs <- character(0)
+      # One block per directory (header + its files), built with lapply (O(n)).
+      dir_blocks <- lapply(dir_paths, function(dp) {
+        dir_info <- hierarchy[[dp]]
+        if (isTRUE(dir_info$is_file)) return(NULL)
 
-      # Process directories and files
-      for (dir_path in dir_paths) {
-        dir_info <- hierarchy[[dir_path]]
-
-        # Skip files (we'll handle them with their parent directories)
-        if (dir_info$is_file) {
-          next
-        }
-
-        # Display the directory header
         dir_indentation <- paste0(rep("&nbsp;", dir_info$level * 3), collapse = "")
-
-        # Get files in this directory (with full paths for selection)
         dir_file_paths <- if (length(dir_info$files) > 0) {
-          paste0(dir_path, "/", dir_info$files)
+          paste0(dp, "/", dir_info$files)
         } else {
           character(0)
         }
-
-        # Check if any files in this directory are selected
-        current_selection <- selected()
         dir_selected <- any(dir_file_paths %in% current_selection)
-        all_selected <- length(dir_file_paths) > 0 && all(dir_file_paths %in% current_selection)
+        all_selected <- length(dir_file_paths) > 0 &&
+          all(dir_file_paths %in% current_selection)
 
-        # Add directory
-        ui_elements <- tagAppendChild(ui_elements,
-                                      div(
-                                        style = paste0(
-                                          "margin-top: 5px; font-weight: bold; cursor: pointer; ",
-                                          if (all_selected) "color: #2196F3;" else if (dir_selected) "color: #64B5F6;" else ""
-                                        ),
-                                        # Directory indentation and name
-                                        HTML(paste0(dir_indentation, dir_info$name, "/")),
-                                        onclick = paste0("Shiny.setInputValue('", session$ns("select_dir"), "', '",
-                                                         dir_path, "', {priority: 'event'})")
-                                      )
+        header <- div(
+          style = paste0(
+            "margin-top: 5px; font-weight: bold; cursor: pointer; ",
+            if (all_selected) "color: #2196F3;" else if (dir_selected) "color: #64B5F6;" else ""
+          ),
+          HTML(paste0(dir_indentation, dir_info$name, "/")),
+          onclick = paste0("Shiny.setInputValue('", ns("select_dir"), "', '",
+                           dp, "', {priority: 'event'})")
         )
 
-        # Add files in this directory
-        if (length(dir_info$files) > 0) {
-          # Sort files alphabetically
-          sorted_files <- sort(dir_info$files)
-
-          for (filename in sorted_files) {
-            file_path <- paste0(dir_path, "/", filename)
+        file_rows <- if (length(dir_info$files) > 0) {
+          lapply(sort(dir_info$files), function(filename) {
+            file_path <- paste0(dp, "/", filename)
             is_selected <- file_path %in% current_selection
-
-            ui_elements <- tagAppendChild(ui_elements,
-                                          div(
-                                            style = paste0(
-                                              "padding: 2px 5px; margin: 1px 0; cursor: pointer; ",
-                                              if (is_selected) "background-color: #e3f2fd; border-radius: 3px;" else ""
-                                            ),
-                                            # File indentation and name
-                                            HTML(paste0(dir_indentation, "&nbsp;&nbsp;&nbsp;", filename)),
-                                            onclick = paste0("Shiny.setInputValue('", session$ns("toggle_file"), "', '",
-                                                             file_path, "', {priority: 'event'})")
-                                          )
+            div(
+              style = paste0(
+                "padding: 2px 5px; margin: 1px 0; cursor: pointer; ",
+                if (is_selected) "background-color: #e3f2fd; border-radius: 3px;" else ""
+              ),
+              HTML(paste0(dir_indentation, "&nbsp;&nbsp;&nbsp;", filename)),
+              onclick = paste0("Shiny.setInputValue('", ns("toggle_file"), "', '",
+                               file_path, "', {priority: 'event'})")
             )
-          }
+          })
+        } else {
+          list()
         }
-      }
 
-      # Add root files (if any)
-      root_files <- files[!grepl("/", files)]
+        tagList(header, file_rows)
+      })
+      dir_blocks <- Filter(Negate(is.null), dir_blocks)
+
+      # Root-level files (no "/" in the relative path).
+      root_files <- sort(files[!grepl("/", files)])
+      root_block <- list()
       if (length(root_files) > 0) {
-        # Sort root files alphabetically
-        root_files <- sort(root_files)
-
-        # Add a header for root files only if there are also subdirectories
-        # (otherwise it's redundant to say "Root files" when there are no subdirs)
         if (length(dir_paths) > 0) {
-          ui_elements <- tagAppendChild(ui_elements,
-                                        div(
-                                          style = "margin-top: 8px; font-weight: bold;",
-                                          "Root files:"
-                                        )
-          )
+          root_block <- c(root_block, list(
+            div(style = "margin-top: 8px; font-weight: bold;", "Root files:")
+          ))
         }
-
-        # Add each root file
-        current_selection <- selected()
-        for (file in root_files) {
+        root_rows <- lapply(root_files, function(file) {
           is_selected <- file %in% current_selection
-
-          ui_elements <- tagAppendChild(ui_elements,
-                                        div(
-                                          style = paste0(
-                                            "padding: 2px 5px; margin: 1px 0; cursor: pointer; ",
-                                            if (is_selected) "background-color: #e3f2fd; border-radius: 3px;" else ""
-                                          ),
-                                          # File indentation and name (no indentation if no subdirs)
-                                          HTML(if (length(dir_paths) > 0) paste0("&nbsp;&nbsp;&nbsp;", file) else file),
-                                          onclick = paste0("Shiny.setInputValue('", session$ns("toggle_file"), "', '",
-                                                           file, "', {priority: 'event'})")
-                                        )
+          div(
+            style = paste0(
+              "padding: 2px 5px; margin: 1px 0; cursor: pointer; ",
+              if (is_selected) "background-color: #e3f2fd; border-radius: 3px;" else ""
+            ),
+            HTML(if (length(dir_paths) > 0) paste0("&nbsp;&nbsp;&nbsp;", file) else file),
+            onclick = paste0("Shiny.setInputValue('", ns("toggle_file"), "', '",
+                             file, "', {priority: 'event'})")
           )
-        }
+        })
+        root_block <- c(root_block, root_rows)
       }
 
-      return(ui_elements)
+      count_div <- div(
+        style = "color: #999; font-size: 12px; margin-bottom: 10px;",
+        paste0("Found ", length(files), " data files, selected ", num_selected)
+      )
+
+      do.call(tagList, c(list(count_div), dir_blocks, root_block))
     })
 
     # Return selected files

--- a/inst/shiny/modules/ui_modules.R
+++ b/inst/shiny/modules/ui_modules.R
@@ -109,31 +109,6 @@ stepProgressUI <- function(current_step, id) {
   )
 }
 
-#' Create Directory Selection Input
-#'
-#' @param id Base ID for the input elements
-#' @param value Initial value for the directory path
-#' @param placeholder Placeholder text for the input
-#' @return UI element for directory selection
-directoryInputUI <- function(id, value = "", placeholder = "Project directory path") {
-  div(
-    class = "directory-input",
-    textInput(
-      NS(id, "path"),
-      label = NULL,
-      value = value,
-      placeholder = placeholder,
-      width = "100%"
-    ),
-    shinyDirButton(
-      NS(id, "select"),
-      label = "...",
-      title = "Select a project directory",
-      class = "browse-btn"
-    )
-  )
-}
-
 #' File Browser UI Component
 #' 
 #' @param id Module ID


### PR DESCRIPTION
The shinyFiles directory chooser runs its fileGetter on every folder it opens -- dir_ls + fs::file_info (a full stat per entry) + dir.exists -- and filters only afterward. Pointing it at a folder with ~100k files blocked the single-threaded R process and shipped a ~100k-row payload to the browser, freezing/hanging weaker machines (Chromebooks, low-RAM PCs) while fast machines pushed through unnoticed. See #49.

A folder picker never needs file metadata, so replace it with a files-free picker and apply the same principle to the step-1 file browser:

- Add inst/shiny/modules/directory_picker.R: drop-in directoryInputUI / directoryInputServer that enumerate ONE level of subdirectories only, via fs::dir_ls(type = directory) (classified from the readdir d_type, no per-entry stat), never touching files. ~4x faster than base list.dirs on the same folder (median 74ms vs 286ms) with a tiny client payload.
- Explain in the modal that only folders are listed (Psych-DS selects a folder, not individual files) and add direct-path entry: Open here browses from a pasted path, Use this path selects it outright. Add a per-session cache so re-navigation is instant.
- Remove the old shinyDirButton directoryInputUI (ui_modules.R) and shinyDirChoose directoryInputServer (server_modules.R); source the new module from global.R.
- File browser: scan with fs::dir_ls and cache it in reactives so it runs once per directory instead of on every file click, and build the tree with tagList(lapply()) (O(n)) instead of tagAppendChild in a loop (O(n^2)).
- DESCRIPTION: add fs to Suggests (used behind requireNamespace with a base-R fallback; installed transitively via shinyFiles regardless).

Fixes #49